### PR TITLE
JSON Formatting Workaround

### DIFF
--- a/src/fileoutput.py
+++ b/src/fileoutput.py
@@ -6,6 +6,7 @@ class FileOutput:
      self.output.write(b"[")
 
   def onAccepted(self, lineBytes):
+   self.output.write(b",")
    self.output.write(b"\n")
    self.output.write(b"\t")
    self.output.write(lineBytes)

--- a/src/fileoutput.py
+++ b/src/fileoutput.py
@@ -6,10 +6,10 @@ class FileOutput:
      self.output.write(b"[")
 
   def onAccepted(self, lineBytes):
-   self.output.write(b",")
    self.output.write(b"\n")
    self.output.write(b"\t")
    self.output.write(lineBytes)
+   self.output.write(b",")
    return
 
   def close(self):


### PR DESCRIPTION
I have implemented a workaround for JSON formatting by adding an output line that adds a comma at the end of each line, prior to starting the next line, resulting in (mostly) corrected JSON structure.

The file would previously output the following incorrect data:
```

[
        {"id64":1183297016522,"name":"Ross 788","coords":{"x":-49.5,"y":-51.75,"z":-45.15625}}
        {"id64":2003342182755,"name":"64 Piscium","coords":{"x":-44.84375,"y":-54.71875,"z":-29.125}}
        {"id64":3107442365130,"name":"Brivitt","coords":{"x":-45.8125,"y":-63.09375,"z":-36.875}}
        {"id64":9466510452121,"name":"Vetta","coords":{"x":-43.625,"y":-46.5,"z":-34.46875}}
]
```

The line in question was

```
self.output.write(b",")
```

and results in the following output

```
[
        {"id64":1183297016522,"name":"Ross 788","coords":{"x":-49.5,"y":-51.75,"z":-45.15625}},
        {"id64":2003342182755,"name":"64 Piscium","coords":{"x":-44.84375,"y":-54.71875,"z":-29.125}},
        {"id64":3107442365130,"name":"Brivitt","coords":{"x":-45.8125,"y":-63.09375,"z":-36.875}},
        {"id64":9466510452121,"name":"Vetta","coords":{"x":-43.625,"y":-46.5,"z":-34.46875}},
]
```

This still isn't correct, as it has a comma following the last entry in the list, but I'm not quite sure how to correct this. I was hoping maybe you'd have an idea that would fix the last entry. Either way, it's closer to what will work within Grafana.